### PR TITLE
Reduce navbar height and add spacing to prevent content cutoff

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ export default function Home() {
   return (
     <main className="min-h-screen">
       <Navigation />
+      <div className="h-16" />
       <HeroSection />
       <AboutSection />
       <ServicesSection />

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -12,13 +12,13 @@ export function Navigation() {
   return (
     <nav className="fixed top-0 w-full z-50 bg-background/80 backdrop-blur-md border-b border-border">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-20">
+        <div className="flex justify-between items-center h-16">
           <div className="flex items-center space-x-4">
             <Image
               src="/images/logo.png"
               alt="Blue Horizon Detailing"
-              width={60}
-              height={60}
+              width={52}
+              height={52}
               className="rounded-full"
             />
             <div>


### PR DESCRIPTION
## Purpose
Fix layout issue where the navbar was cutting off the slogan content below it. The user requested to make the navbar thinner and move the slogan down to ensure 100% visibility without any cutoff.

## Code changes
- **Navigation component**: Reduced navbar height from `h-20` to `h-16` (80px to 64px)
- **Logo sizing**: Decreased logo dimensions from 60x60px to 52x52px to fit the thinner navbar
- **Main page layout**: Added a 16px spacer div (`h-16`) after the Navigation component to push the HeroSection content down and prevent overlap with the fixed navbarTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5df9f393cf9348ee995f2a718d657df8/mystic-zone)

👀 [Preview Link](https://5df9f393cf9348ee995f2a718d657df8-mystic-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5df9f393cf9348ee995f2a718d657df8</projectId>-->
<!--<branchName>mystic-zone</branchName>-->